### PR TITLE
Remove false information from guides

### DIFF
--- a/content/guides/nyc-sf.md
+++ b/content/guides/nyc-sf.md
@@ -1,40 +1,27 @@
-An NYC Evening in SF: Energy, Elegance, and Italian Food
-NYC energy is a mix of effortless nightlife, an electric atmosphere, and food that sets the scene. It’s always a combination of being well-dressed, classy cocktails, a great Italian meal, and walking through the night with energy. That’s the formula. And San Francisco is so back—if you know where to look.
+An NYC-Style Evening in San Francisco
+This short guide offers a straightforward itinerary for experiencing a night in San Francisco that echoes a classic New York City progression: a wine bar to start, an Italian dinner, and a speakeasy-style cocktail lounge.
 
-Let’s take you on a night out that hits the right notes, NYC-style.
+## Itinerary
 
-The Itinerary: A Perfect NYC-Inspired Night in SF
-1. SF Is So Back – Verjus
-📍 Verjus (Revived Wine Bar, Legendary Status)
+1. **Verjus**  
+   • Reopened in October 2024 after a four-year closure (Jackson Square).  
+   • Natural-wine focus with French-leaning small plates.  
+   • Walk-in friendly early in the evening.
 
-This spot was shut down for a few years, but it’s back, and the energy is real. Originally started by the all-star crew behind Quince, Verjus was the spot for intern season 2019, and yeah—great skin-contact wine. It feels like a natural wine bar straight out of West Village—small plates, great pours, and the kind of place where you start the night and forget to leave.
+2. **Cotogna**  
+   • Italian restaurant from the Quince team, one block away.  
+   • Handmade pasta, seasonal produce, wood-fired mains.  
+   • Reservations recommended.
 
-🗽 NYC Equivalent: Stafilli Wine (West Village), Sauced (East Village)
-🌉 SF Alternative: Bar Sprezzatura
+3. **Cold Drinks Bar**  
+   • Scotch-leaning cocktail bar above China Live in Chinatown.  
+   • Dark, speakeasy-style setting; smart-casual dress fits in.  
+   • Consider booking a table on weekends.
 
-2. Italian Forever – Cotogna
-📍 Cotogna (Handmade Pasta, Wood-Fired Perfection)
+## Optional Add-Ons
+• Stand-up at **Cobb’s Comedy Club** or **Punch Line**.  
+• Skyline view at **Top of the Mark**.  
+• Late-night dancing at **Bar Part Time**.  
+• Evening walk through **North Beach**.
 
-Italian food is non-negotiable for a perfect night. Cotogna is the Rezdora-Torrisi crossover SF needed—warm lighting, handmade pastas, crispy focaccia, and fire-kissed meats. If you’re debating what to order, get the agnolotti and wood-grilled steak. It’s got that old-school Italian magic with a modern SF touch.
-
-🗽 NYC Equivalent: Rezdora (Midtown), Torrisi (Little Italy)
-🌉 SF Alternative: Tony’s Pizza Napoletana (#2 in the US)—and yeah, it’s that good.
-
-3. A Classy Speakeasy – Cold Drinks Bar
-📍 Cold Drinks Bar (Moody, Mysterious, Cinematic)
-
-You need a late-night spot with mystery, a little Chinatown intrigue, and upscale cocktail energy. Cold Drinks Bar delivers on all fronts. It’s giving slight Chinatown, but with that polished cocktail fusion, straight out of a movie. You walk in, and suddenly it’s La La Land with a Blade Runner twist. This is why you gotta dress up—velvet booths, moody lighting, and a cocktail in hand? Flawless.
-
-🗽 NYC Equivalent: Attaboy (Lower East Side), Ye’s Apothecary (Williamsburg)
-🌉 SF Alternative: Moongate Lounge (Sleek, upstairs Chinatown vibes)
-
-Bonus NYC Moves
-Want to go deeper into the energy? Add one (or all) of these:
-
-🎤 Comedy Night → Cobb’s or Punch Line for a classic NYC-style stand-up set.
-🌆 Views at Top of the Mark → A skyline moment, just like an NYC rooftop.
-💃 Dance at Bar Part Time → House music, dim lights, late-night movement.
-🛤️ Stroll North Beach → SF’s Greenwich Village moment.
-
-The Verdict?
-The NYC formula works anywhere—all you need is a good wine bar, a great Italian meal, and a proper speakeasy. San Francisco delivers its own version, and if you hit the right spots, you feel that pulse.
+Enjoy your night out!


### PR DESCRIPTION
Remove subjective and unverifiable claims from `nyc-sf.md` guide.